### PR TITLE
Fix webhook URL validation in DiscordMonologHandler

### DIFF
--- a/src/DiscordMonologHandler.php
+++ b/src/DiscordMonologHandler.php
@@ -23,7 +23,7 @@ class DiscordMonologHandler extends AbstractProcessingHandler
 
     protected function write(LogRecord $record): void
     {
-        if (empty($this->webhookUrl) || !str_starts_with($this->webhookUrl, 'https://')) {
+        if (!str_starts_with($this->webhookUrl, 'https://')) {
             return;
         }
 

--- a/src/DiscordMonologHandler.php
+++ b/src/DiscordMonologHandler.php
@@ -23,7 +23,7 @@ class DiscordMonologHandler extends AbstractProcessingHandler
 
     protected function write(LogRecord $record): void
     {
-        if (empty($webhookUrl) || !str_starts_with($webhookUrl, 'https://')) {
+        if (empty($this->webhookUrl) || !str_starts_with($this->webhookUrl, 'https://')) {
             return;
         }
 


### PR DESCRIPTION
The commit resolves an issue with the webhook URL validation in the write method of the DiscordMonologHandler. It references the correct instance property `$this->webhookUrl` instead of the undefined local variable `$webhookUrl`.